### PR TITLE
Add automatic wallet network switching

### DIFF
--- a/apps/web/components/endpoint-browser-runner.test.tsx
+++ b/apps/web/components/endpoint-browser-runner.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 
 import React from "react";
-import { render, screen, waitFor } from "@testing-library/react";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -14,6 +14,7 @@ const mockConnector = {
     publicKey: "pubkey"
   })),
   getActiveNetwork: vi.fn(async () => "mainnet"),
+  switchNetwork: vi.fn(async (network: string) => network),
   sign: vi.fn(async () => ({
     signature: "signed_challenge"
   })),
@@ -44,11 +45,13 @@ describe("EndpointBrowserRunner", () => {
     mockConnector.connect.mockClear();
     mockConnector.exportKeys.mockClear();
     mockConnector.getActiveNetwork.mockClear();
+    mockConnector.switchNetwork.mockClear();
     mockConnector.sign.mockClear();
     mockConnector.transfer.mockClear();
   });
 
   afterEach(() => {
+    cleanup();
     globalThis.fetch = originalFetch;
     vi.restoreAllMocks();
   });
@@ -141,5 +144,85 @@ describe("EndpointBrowserRunner", () => {
 
     expect(fetchImpl).toHaveBeenCalledTimes(3);
     expect(mockConnector.transfer).not.toHaveBeenCalled();
+  });
+
+  it("auto-switches the wallet network before running a wallet-session endpoint", async () => {
+    const user = userEvent.setup();
+    mockConnector.getActiveNetwork.mockResolvedValueOnce("mainnet").mockResolvedValueOnce("testnet");
+
+    const fetchImpl = vi.fn(async (input: string | URL | Request) => {
+      const url = typeof input === "string" ? input : input.toString();
+
+      if (url.endsWith("/auth/challenge")) {
+        return jsonResponse(200, {
+          nonce: "nonce_123",
+          expiresAt: "2026-03-21T00:05:00.000Z",
+          message: "Sign this challenge"
+        });
+      }
+
+      if (url.endsWith("/auth/session")) {
+        return jsonResponse(200, {
+          accessToken: "api_session_token"
+        });
+      }
+
+      return jsonResponse(200, {
+        orderId: "order_123",
+        status: "ready"
+      });
+    });
+    globalThis.fetch = fetchImpl as unknown as typeof fetch;
+
+    render(
+      <EndpointBrowserRunner
+        deploymentNetwork="testnet"
+        endpoint={{
+          endpointType: "marketplace_proxy",
+          routeId: "orders.lookup.v1",
+          title: "Lookup order",
+          description: "Read one prepaid order.",
+          price: "Prepaid credit",
+          billingType: "prepaid_credit",
+          tokenSymbol: "testUSDC",
+          mode: "sync",
+          method: "GET",
+          path: "/api/orders/lookup",
+          proxyUrl: "https://api.marketplace.example.com/api/orders/lookup",
+          requestSchemaJson: {
+            type: "object",
+            properties: {
+              id: { type: "string" }
+            },
+            required: ["id"],
+            additionalProperties: false
+          },
+          responseSchemaJson: {
+            type: "object",
+            properties: {
+              orderId: { type: "string" },
+              status: { type: "string" }
+            },
+            required: ["orderId", "status"],
+            additionalProperties: false
+          },
+          requestExample: {
+            id: "order_123"
+          },
+          responseExample: {
+            orderId: "order_123",
+            status: "ready"
+          },
+          usageNotes: undefined
+        }}
+      />
+    );
+
+    await user.click(screen.getByRole("button", { name: /authorize and run in browser/i }));
+
+    await waitFor(() => {
+      expect(mockConnector.switchNetwork).toHaveBeenCalledWith("testnet");
+    });
+    expect(mockConnector.exportKeys).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/web/components/endpoint-browser-runner.tsx
+++ b/apps/web/components/endpoint-browser-runner.tsx
@@ -14,6 +14,7 @@ import {
   createApiAccessToken,
   createJobAccessToken,
   createPaymentIdentifier,
+  ensureConnectorDeploymentNetwork,
   encodeBrowserPaymentPayload,
   formatResponseBody,
   paymentNetworkForDeployment,
@@ -456,25 +457,10 @@ async function ensureConnector(
     throw new Error("Wallet connection was rejected.");
   }
 
-  if (connector.getActiveNetwork) {
-    const active = await connector.getActiveNetwork().catch(() => null);
-    if (active && !matchesDeploymentNetwork(active, deploymentNetwork)) {
-      throw new Error(`Wallet is on ${active}. Switch it to ${deploymentNetwork} for this endpoint.`);
-    }
-  }
+  await ensureConnectorDeploymentNetwork(connector, deploymentNetwork, "endpoint");
 
   connectorRef.current = connector;
   return connector;
-}
-
-function matchesDeploymentNetwork(active: string, deploymentNetwork: WebDeploymentNetwork): boolean {
-  const normalized = active.trim().toLowerCase();
-
-  if (deploymentNetwork === "testnet") {
-    return normalized === "testnet" || normalized === "fast-testnet";
-  }
-
-  return normalized === "mainnet" || normalized === "fast-mainnet";
 }
 
 async function safeJson(response: Response): Promise<unknown> {

--- a/apps/web/components/wallet-login-button.test.tsx
+++ b/apps/web/components/wallet-login-button.test.tsx
@@ -13,6 +13,7 @@ const connectMock = vi.fn();
 const disconnectMock = vi.fn();
 const exportKeysMock = vi.fn();
 const getActiveNetworkMock = vi.fn();
+const switchNetworkMock = vi.fn();
 const signMock = vi.fn();
 const fromInjectedMock = vi.fn();
 const getInjectedFastConnectorMock = vi.fn();
@@ -42,6 +43,7 @@ describe("WalletLoginButton", () => {
       address: "fast1provider000000000000000000000000000000000000000000000000000000"
     });
     getActiveNetworkMock.mockResolvedValue("mainnet");
+    switchNetworkMock.mockImplementation(async (network: string) => network);
     signMock.mockResolvedValue({
       signature: "signed-wallet-challenge"
     });
@@ -50,6 +52,7 @@ describe("WalletLoginButton", () => {
       disconnect: disconnectMock,
       exportKeys: exportKeysMock,
       getActiveNetwork: getActiveNetworkMock,
+      switchNetwork: switchNetworkMock,
       sign: signMock
     });
     getInjectedFastConnectorMock.mockReturnValue({ provider: "injected" });
@@ -186,5 +189,51 @@ describe("WalletLoginButton", () => {
         )
       ).toBeTruthy();
     });
+  });
+
+  it("auto-switches the wallet network before site login when the extension supports it", async () => {
+    getActiveNetworkMock.mockResolvedValueOnce("mainnet").mockResolvedValueOnce("testnet");
+
+    vi.spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            wallet: "fast1provider000000000000000000000000000000000000000000000000000000",
+            resourceType: "site",
+            resourceId: window.location.origin,
+            nonce: "nonce-1",
+            expiresAt: "2026-03-25T00:00:00.000Z",
+            message: "Sign in to Fast Marketplace"
+          }),
+          { status: 200, headers: { "content-type": "application/json" } }
+        )
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            accessToken: "wallet-session-token",
+            wallet: "fast1provider000000000000000000000000000000000000000000000000000000",
+            resourceType: "site",
+            resourceId: window.location.origin,
+            tokenType: "Bearer"
+          }),
+          { status: 200, headers: { "content-type": "application/json" } }
+        )
+      );
+
+    render(
+      <WalletLoginButton
+        apiBaseUrl=""
+        deploymentNetwork="testnet"
+        networkLabel="Testnet"
+      />
+    );
+
+    await userEvent.click(screen.getByRole("button", { name: /connect to fast/i }));
+
+    await waitFor(() => {
+      expect(switchNetworkMock).toHaveBeenCalledWith("testnet");
+    });
+    expect(exportKeysMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/web/components/wallet-login-button.tsx
+++ b/apps/web/components/wallet-login-button.tsx
@@ -16,11 +16,11 @@ import {
 import {
   WALLET_SESSION_CHANGE_EVENT,
   clearStoredWalletSession,
-  normalizeWalletConnectorNetwork,
   readStoredWalletSession,
   shortenWalletAddress,
   writeStoredWalletSession
 } from "@/lib/wallet-session";
+import { ensureConnectorDeploymentNetwork } from "@/lib/browser-x402";
 
 interface WalletChallengeResponse {
   wallet: string;
@@ -130,14 +130,7 @@ export function WalletLoginButton({
         throw new Error("Wallet connection was rejected.");
       }
 
-      const activeNetwork = normalizeWalletConnectorNetwork(
-        (await connector.getActiveNetwork().catch(() => null)) ?? deploymentNetwork
-      );
-
-      if (activeNetwork && activeNetwork !== deploymentNetwork) {
-        await connector.disconnect();
-        throw new Error(`Wallet is on ${activeNetwork}. Switch it to ${deploymentNetwork} for this site.`);
-      }
+      await ensureConnectorDeploymentNetwork(connector, deploymentNetwork, "site");
 
       const account = await connector.exportKeys();
       const challengeResponse = await fetch(`${apiBaseUrl.replace(/\/$/, "")}/auth/wallet/challenge`, {

--- a/apps/web/lib/browser-x402.ts
+++ b/apps/web/lib/browser-x402.ts
@@ -22,6 +22,7 @@ export interface BrowserConnectorLike {
   connect(): Promise<boolean>;
   exportKeys(): Promise<{ address: string; publicKey: string }>;
   getActiveNetwork?(): Promise<string>;
+  switchNetwork?(network: WebDeploymentNetwork): Promise<string>;
   sign(params: { message: string | Uint8Array }): Promise<{ signature: string }>;
   transfer(params: {
     amount: string;
@@ -94,6 +95,44 @@ export function formatResponseBody(body: unknown): string {
   }
 
   return JSON.stringify(body, null, 2);
+}
+
+export function matchesDeploymentNetwork(
+  active: string,
+  deploymentNetwork: WebDeploymentNetwork
+): boolean {
+  const normalized = active.trim().toLowerCase();
+
+  if (deploymentNetwork === "testnet") {
+    return normalized === "testnet" || normalized === "fast-testnet";
+  }
+
+  return normalized === "mainnet" || normalized === "fast-mainnet";
+}
+
+export async function ensureConnectorDeploymentNetwork(
+  connector: BrowserConnectorLike,
+  deploymentNetwork: WebDeploymentNetwork,
+  targetLabel: "site" | "endpoint"
+): Promise<void> {
+  if (!connector.getActiveNetwork) {
+    return;
+  }
+
+  const active = await connector.getActiveNetwork().catch(() => null);
+  if (!active || matchesDeploymentNetwork(active, deploymentNetwork)) {
+    return;
+  }
+
+  if (!connector.switchNetwork) {
+    throw new Error(`Wallet is on ${active}. Switch it to ${deploymentNetwork} for this ${targetLabel}.`);
+  }
+
+  await connector.switchNetwork(deploymentNetwork);
+  const updated = await connector.getActiveNetwork().catch(() => null);
+  if (!updated || !matchesDeploymentNetwork(updated, deploymentNetwork)) {
+    throw new Error(`Wallet is on ${updated ?? active}. Switch it to ${deploymentNetwork} for this ${targetLabel}.`);
+  }
 }
 
 async function createScopedAccessToken(input: {


### PR DESCRIPTION
## Summary
- add a shared browser connector helper that attempts wallet network switching before site auth and endpoint execution
- use the helper in the wallet login flow and browser endpoint runner
- cover the auto-switch path in web tests

## Verification
- npm test ✅
- npm run build ❌ killed during build:runtime (tsup) with signal 9 in this environment