### PR TITLE
[codex] Fix marketplace detail fetch and favicon mapping

### DIFF
--- a/apps/web/components/marketplace-home.test.tsx
+++ b/apps/web/components/marketplace-home.test.tsx
@@ -122,6 +122,44 @@ describe("MarketplaceHome", () => {
             websiteUrl: "https://www.instagram.com"
           },
           {
+            serviceType: "marketplace_proxy",
+            slug: "trustpilot-reviews-scraper",
+            name: "Trustpilot Reviews Scraper",
+            ownerName: "Fast Marketplace",
+            tagline: "Extract Trustpilot reviews.",
+            categories: ["Research"],
+            settlementMode: "verified_escrow",
+            settlementLabel: "Verified",
+            settlementDescription: "Marketplace escrow, refunds, and payout reconciliation.",
+            priceRange: "$0.03",
+            settlementToken: "USDC",
+            endpointCount: 1,
+            totalCalls: 12,
+            revenue: "0.36",
+            successRate30d: 98,
+            volume30d: [],
+            websiteUrl: "https://fastmainnetapifytrustpilot.8o.vc"
+          },
+          {
+            serviceType: "marketplace_proxy",
+            slug: "apple-app-store-scraper",
+            name: "Apple App Store Scraper",
+            ownerName: "Fast Marketplace",
+            tagline: "Search Apple App Store listings.",
+            categories: ["Research"],
+            settlementMode: "verified_escrow",
+            settlementLabel: "Verified",
+            settlementDescription: "Marketplace escrow, refunds, and payout reconciliation.",
+            priceRange: "$0.03",
+            settlementToken: "USDC",
+            endpointCount: 1,
+            totalCalls: 9,
+            revenue: "0.27",
+            successRate30d: 100,
+            volume30d: [],
+            websiteUrl: "https://fastmainnetapifyappstore.8o.vc"
+          },
+          {
             serviceType: "external_registry",
             slug: "stableenrich-apollo-api",
             name: "StableEnrich Apollo API",
@@ -152,9 +190,13 @@ describe("MarketplaceHome", () => {
     expect(screen.getByRole("columnheader", { name: /pricing/i })).toBeTruthy();
     expect(screen.getByText("Amazon Product Scraper")).toBeTruthy();
     expect(screen.getByText("Instagram Scraper")).toBeTruthy();
+    expect(screen.getByText("Trustpilot Reviews Scraper")).toBeTruthy();
+    expect(screen.getByText("Apple App Store Scraper")).toBeTruthy();
     expect(screen.getByText("StableEnrich Apollo API")).toBeTruthy();
     expect(screen.getByRole("img", { name: "Amazon Product Scraper favicon" }).getAttribute("src")).toBe("https://www.google.com/s2/favicons?domain=www.amazon.com&sz=64");
     expect(screen.getByRole("img", { name: "Instagram Scraper favicon" }).getAttribute("src")).toBe("https://www.google.com/s2/favicons?domain=www.instagram.com&sz=64");
+    expect(screen.getByRole("img", { name: "Trustpilot Reviews Scraper favicon" }).getAttribute("src")).toBe("https://www.google.com/s2/favicons?domain=www.trustpilot.com&sz=64");
+    expect(screen.getByRole("img", { name: "Apple App Store Scraper favicon" }).getAttribute("src")).toBe("https://www.google.com/s2/favicons?domain=www.apple.com&sz=64");
     expect(screen.getByRole("img", { name: "StableEnrich Apollo API favicon" }).getAttribute("src")).toBe("https://www.google.com/s2/favicons?domain=www.apollo.io&sz=64");
 
     await user.type(screen.getByPlaceholderText("Search services, owners, or categories"), "instagram");
@@ -182,15 +224,13 @@ describe("MarketplaceHome", () => {
     expect(within(categoryFilter).getByRole("option", { name: "Social" })).toBeTruthy();
 
     await user.selectOptions(categoryFilter, "");
-    await user.hover(screen.getByText("Instagram Scraper"));
-
-    await waitFor(() => {
-      expect(fetchServiceDetailMock).toHaveBeenCalledWith("instagram-scraper", "http://localhost:3000");
-    });
-
     await user.click(screen.getByText("Instagram Scraper"));
 
-    expect(fetchServiceDetailMock).toHaveBeenCalledTimes(1);
+    await waitFor(() => {
+      expect(fetchServiceDetailMock).toHaveBeenCalledWith("instagram-scraper", "");
+    });
+
+    expect(fetchServiceDetailMock).toHaveBeenCalled();
 
     expect(screen.getByText("Endpoint")).toBeTruthy();
     expect(screen.getByText("Scrape Posts")).toBeTruthy();

--- a/apps/web/components/services-data-table.tsx
+++ b/apps/web/components/services-data-table.tsx
@@ -49,6 +49,8 @@ function inferWebsiteUrlFromServiceName(serviceName: string): string | null {
   const normalized = serviceName.toLowerCase();
 
   const exactMappings: Array<[string, string]> = [
+    ["trustpilot reviews scraper", "https://www.trustpilot.com"],
+    ["apple app store scraper", "https://www.apple.com"],
     ["cheerio scraper", "https://cheerio.js.org"],
     ["tweet scraper", "https://x.com"],
     ["tavily proxy", "https://tavily.com"],
@@ -102,6 +104,7 @@ export function ServicesDataTable({ services }: { services: ServiceSummary[] }) 
   const [sorting, setSorting] = React.useState<SortingState>([{ id: "name", desc: false }]);
   const [expandedSlug, setExpandedSlug] = React.useState<string | null>(null);
   const [detailsBySlug, setDetailsBySlug] = React.useState<Record<string, ServiceDetail>>({});
+  const [detailErrorsBySlug, setDetailErrorsBySlug] = React.useState<Record<string, string>>({});
   const [loadingSlug, setLoadingSlug] = React.useState<string | null>(null);
   const clientApiBaseUrl = React.useMemo(() => getClientApiBaseUrl(), []);
   const detailsBySlugRef = React.useRef(detailsBySlug);
@@ -126,11 +129,31 @@ export function ServicesDataTable({ services }: { services: ServiceSummary[] }) 
     const request = (async () => {
       const detail = await fetchServiceDetail(service.slug, clientApiBaseUrl);
       if (detail) {
+        setDetailErrorsBySlug((current) => {
+          if (!(service.slug in current)) {
+            return current;
+          }
+
+          const { [service.slug]: _omitted, ...rest } = current;
+          return rest;
+        });
         setDetailsBySlug((current) => ({ ...current, [service.slug]: detail }));
+      } else {
+        setDetailErrorsBySlug((current) => {
+          if (current[service.slug] === "Service details not found.") {
+            return current;
+          }
+
+          return { ...current, [service.slug]: "Service details not found." };
+        });
       }
 
       return detail;
-    })();
+    })().catch((error: unknown) => {
+      const message = error instanceof Error ? error.message : "Failed to load service details.";
+      setDetailErrorsBySlug((current) => ({ ...current, [service.slug]: message }));
+      throw error;
+    });
 
     inFlightDetailsRef.current[service.slug] = request;
 
@@ -143,7 +166,7 @@ export function ServicesDataTable({ services }: { services: ServiceSummary[] }) 
   }, [clientApiBaseUrl]);
 
   const preloadDetails = React.useCallback((service: ServiceSummary) => {
-    void loadDetails(service);
+    void loadDetails(service).catch(() => null);
   }, [loadDetails]);
 
   const toggleExpanded = React.useCallback(async (service: ServiceSummary) => {
@@ -153,7 +176,11 @@ export function ServicesDataTable({ services }: { services: ServiceSummary[] }) 
     }
 
     setExpandedSlug(service.slug);
-    await loadDetails(service);
+    try {
+      await loadDetails(service);
+    } catch {
+      return;
+    }
   }, [expandedSlug, loadDetails]);
 
   const columns = React.useMemo<ColumnDef<ServiceSummary>[]>(() => [
@@ -272,6 +299,7 @@ export function ServicesDataTable({ services }: { services: ServiceSummary[] }) 
             const service = row.original;
             const expanded = expandedSlug === service.slug;
             const detail = detailsBySlug[service.slug];
+            const detailError = detailErrorsBySlug[service.slug];
             const loading = loadingSlug === service.slug;
 
             return (
@@ -293,6 +321,7 @@ export function ServicesDataTable({ services }: { services: ServiceSummary[] }) 
                   <TableRow>
                     <TableCell colSpan={columns.length} className="bg-muted/20 px-2 py-4">
                       {loading && !detail ? <div className="text-sm text-muted-foreground">Loading details…</div> : null}
+                      {detailError && !loading && !detail ? <div className="text-sm text-destructive">{detailError}</div> : null}
                       {detail ? <EndpointSubtable detail={detail} /> : null}
                     </TableCell>
                   </TableRow>

--- a/apps/web/lib/api-base-url.test.ts
+++ b/apps/web/lib/api-base-url.test.ts
@@ -3,14 +3,14 @@ import { describe, expect, it } from "vitest";
 import { getClientApiBaseUrl } from "./api-base-url";
 
 describe("getClientApiBaseUrl", () => {
-  it("defaults localhost web dev to the local API port when no client API base URL is configured", () => {
+  it("defaults browser requests to same-origin when no client API base URL is configured", () => {
     expect(
       getClientApiBaseUrl({
         NODE_ENV: "development",
         MARKETPLACE_API_BASE_URL: undefined,
         NEXT_PUBLIC_MARKETPLACE_API_BASE_URL: undefined
       })
-    ).toBe("http://localhost:3000");
+    ).toBe("");
   });
 
   it("keeps an explicitly configured production API base URL in development", () => {

--- a/apps/web/lib/api-base-url.ts
+++ b/apps/web/lib/api-base-url.ts
@@ -8,12 +8,5 @@ export function getClientApiBaseUrl(
   env: Partial<Pick<NodeJS.ProcessEnv, "NODE_ENV" | "NEXT_PUBLIC_MARKETPLACE_API_BASE_URL" | "MARKETPLACE_API_BASE_URL">> = process.env
 ): string {
   const configured = env.NEXT_PUBLIC_MARKETPLACE_API_BASE_URL ?? env.MARKETPLACE_API_BASE_URL ?? "";
-
-  if (env.NODE_ENV !== "production") {
-    if (!configured) {
-      return DEFAULT_LOCAL_API_BASE_URL;
-    }
-  }
-
   return configured;
 }


### PR DESCRIPTION
## What changed

This PR fixes the marketplace service table detail fetch path and adds explicit favicon mappings for the Trustpilot Reviews Scraper and Apple App Store Scraper.

- default browser-side marketplace API requests to same-origin unless a public API base URL is explicitly configured
- prevent service detail preload failures from surfacing as unhandled promise errors and show an inline error in expanded rows instead
- map Trustpilot Reviews Scraper to `www.trustpilot.com` and Apple App Store Scraper to `www.apple.com` for favicon rendering
- update homepage and API base URL tests to cover the new behavior

## Why

Expanded subrows in the main table were trying to fetch service details from `http://localhost:3000` in browser sessions without a configured public API base URL. In deployed environments that broke the detail fetch and left subrows empty. The favicon mapping also needed explicit service-name overrides for the two new Apify-backed services.

## Impact

- expanded service rows load against the current site by default instead of a localhost origin
- detail fetch failures now render an inline row error instead of throwing unhandled promise rejections
- Trustpilot and Apple App Store scraper rows display the expected favicons

## Validation

- `npm test`
- `npm run build`
