### PR TITLE
chore: refresh compatible fastxyz packages

### DIFF
--- a/apps/api/src/app.test.ts
+++ b/apps/api/src/app.test.ts
@@ -1,9 +1,10 @@
 import type { Express } from "express";
-import { FastProvider, FastWallet } from "@fastxyz/sdk";
+import { FastProvider } from "@fastxyz/sdk";
 import request from "supertest";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import {
+  MarketplaceFastWallet,
   buildMarketplaceCallbackHeaders,
   InMemoryMarketplaceStore,
   MARKETPLACE_JOB_TOKEN_HEADER,
@@ -21,19 +22,13 @@ const OTHER_PRIVATE_KEY = "44".repeat(32);
 
 async function createTestWallet(privateKey = TEST_PRIVATE_KEY) {
   const provider = new FastProvider({
-    network: "mainnet",
-    networks: {
-      mainnet: {
-        rpc: "https://api.fast.xyz/proxy",
-        explorer: "https://explorer.fast.xyz"
-      }
-    }
+    rpcUrl: "https://api.fast.xyz/proxy"
   });
-  const wallet = await FastWallet.fromPrivateKey(privateKey, provider);
+  const wallet = await MarketplaceFastWallet.fromPrivateKey(privateKey, provider);
   const exported = await wallet.exportKeys();
   return {
     wallet,
-    address: wallet.address,
+    address: await wallet.address,
     payerHex: `0x${exported.publicKey}`
   };
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,11 +10,11 @@
         "packages/*"
       ],
       "dependencies": {
-        "@fastxyz/fast-connector": "^0.1.0",
+        "@fastxyz/fast-connector": "^0.1.1",
         "@fastxyz/sdk": "^0.2.5",
-        "@fastxyz/x402-client": "^0.1.2",
-        "@fastxyz/x402-facilitator": "^0.1.2",
-        "@fastxyz/x402-server": "^0.1.2",
+        "@fastxyz/x402-client": "^0.1.3",
+        "@fastxyz/x402-facilitator": "^1.0.1",
+        "@fastxyz/x402-server": "^1.0.1",
         "@noble/ed25519": "^2.3.0",
         "@noble/hashes": "^1.8.0",
         "ajv": "^8.18.0",
@@ -372,7 +372,9 @@
       }
     },
     "node_modules/@fastxyz/allset-sdk": {
-      "version": "0.1.9",
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/@fastxyz/allset-sdk/-/allset-sdk-0.1.12.tgz",
+      "integrity": "sha512-aMzrVq9ENwIA3RINfHhBe80AbIqWOct/PHPfqSGHMDekHZ8Q5VLIPDSohFPLzId5eyLVkGzOGS+Radzdv4q6fg==",
       "license": "MIT",
       "dependencies": {
         "@mysten/bcs": "^2.0.2",
@@ -415,8 +417,14 @@
       }
     },
     "node_modules/@fastxyz/fast-connector": {
-      "version": "0.1.0",
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@fastxyz/fast-connector/-/fast-connector-0.1.1.tgz",
+      "integrity": "sha512-iJhGac9DplXNCnCCQzNQfoCIO8QA4NISQYDmwzY+vJK1L1oixuMzBg00nQ0gBnyEZDf8n2o6qeGkVLU+y+DWGw==",
       "license": "MIT",
+      "dependencies": {
+        "@mysten/bcs": "^2.0.2",
+        "@noble/hashes": "^1.5.0"
+      },
       "engines": {
         "node": ">=20"
       },
@@ -424,8 +432,20 @@
         "@fastxyz/sdk": ">=0.1.8"
       }
     },
+    "node_modules/@fastxyz/schema": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@fastxyz/schema/-/schema-1.0.1.tgz",
+      "integrity": "sha512-SLdnJRHeZJ5uU+437nwcaqbpKk2IaE5FCRsKwCGMvss5E058UP/lWKhoiNXz1x4Xew+9lltyNd3K34aEeMy2nw==",
+      "dependencies": {
+        "@mysten/bcs": "^2.0.3",
+        "bech32": "^2.0.0",
+        "effect": "^3.21.0"
+      }
+    },
     "node_modules/@fastxyz/sdk": {
       "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/@fastxyz/sdk/-/sdk-0.2.5.tgz",
+      "integrity": "sha512-a2LxkxhmUEcqmGn159ausanthwB5EX2ebm+ElAhv/vwnHD4CwS269B1279RB75XitR0vANm8CZcLX2/+xCo6+w==",
       "license": "MIT",
       "dependencies": {
         "@mysten/bcs": "^2.0.2",
@@ -439,7 +459,9 @@
       }
     },
     "node_modules/@fastxyz/x402-client": {
-      "version": "0.1.2",
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@fastxyz/x402-client/-/x402-client-0.1.3.tgz",
+      "integrity": "sha512-9cAU6Sa7yqOBjSgBMuzyFNQHNBkUOn9owuB6mMjf/J/dosSyA6MTUvi1OBeGP0T2Q51ckXEPplMdmKqtmJdJxw==",
       "license": "MIT",
       "dependencies": {
         "@fastxyz/allset-sdk": "^0.1.8",
@@ -455,19 +477,17 @@
       }
     },
     "node_modules/@fastxyz/x402-facilitator": {
-      "version": "0.1.2",
-      "license": "MIT",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@fastxyz/x402-facilitator/-/x402-facilitator-1.0.1.tgz",
+      "integrity": "sha512-2E7STOOd5TknViz+wjgZ9/19jjKMA9bJUCWpPdrJTO3nOBH0Oo+XahBMy3+MsMloasxFQUPmynOo6rl2cJxgZQ==",
       "dependencies": {
-        "@fastxyz/allset-sdk": "^0.1.8",
-        "@fastxyz/sdk": "^0.2.5",
-        "@mysten/bcs": "^1.2.0",
-        "viem": "^2.21.0"
-      },
-      "engines": {
-        "node": ">=20"
+        "@fastxyz/schema": "1.0.1",
+        "@fastxyz/sdk": "1.0.1",
+        "@fastxyz/x402-types": "1.0.1",
+        "viem": "^2.27.2"
       },
       "peerDependencies": {
-        "express": "^4.18.0"
+        "express": ">=4"
       },
       "peerDependenciesMeta": {
         "express": {
@@ -475,45 +495,62 @@
         }
       }
     },
-    "node_modules/@fastxyz/x402-facilitator/node_modules/@mysten/bcs": {
-      "version": "1.9.2",
-      "license": "Apache-2.0",
+    "node_modules/@fastxyz/x402-facilitator/node_modules/@fastxyz/sdk": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@fastxyz/sdk/-/sdk-1.0.1.tgz",
+      "integrity": "sha512-oE4llbFidOS6du4VmDuFMPgLv34bk/EQKwl0H1cWoibG9yZca47aWKVm2iwgYmsl9o1RVoHUOw4Lz4RVW71sJQ==",
       "dependencies": {
-        "@mysten/utils": "0.2.0",
-        "@scure/base": "^1.2.6"
+        "@fastxyz/schema": "1.0.1",
+        "@mysten/bcs": "^2.0.3",
+        "@noble/ed25519": "^3.0.1",
+        "@noble/hashes": "^2.0.1",
+        "bech32": "^2.0.0",
+        "effect": "^3.21.0",
+        "json-with-bigint": "^3.5.8"
       }
     },
-    "node_modules/@fastxyz/x402-facilitator/node_modules/@mysten/utils": {
-      "version": "0.2.0",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@scure/base": "^1.2.6"
-      }
-    },
-    "node_modules/@fastxyz/x402-facilitator/node_modules/@scure/base": {
-      "version": "1.2.6",
+    "node_modules/@fastxyz/x402-facilitator/node_modules/@noble/ed25519": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@noble/ed25519/-/ed25519-3.0.1.tgz",
+      "integrity": "sha512-t/T8LuK0ym8ALQudCCQCtrRdMSxBnRgHXw+wg+YsSlE6d+on7sX3flqlSJ2mOs9xEuchM36kj9SuX5MG7pXQMA==",
       "license": "MIT",
       "funding": {
         "url": "https://paulmillr.com/funding/"
       }
     },
-    "node_modules/@fastxyz/x402-server": {
-      "version": "0.1.2",
+    "node_modules/@fastxyz/x402-facilitator/node_modules/@noble/hashes": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.0.1.tgz",
+      "integrity": "sha512-XlOlEbQcE9fmuXxrVTXCTlG2nlRXa9Rj3rr5Ue/+tX+nmkgbX720YHh0VR3hBF9xDvwnb8D2shVGOwNx+ulArw==",
       "license": "MIT",
-      "dependencies": {
-        "@fastxyz/allset-sdk": "^0.1.8"
-      },
       "engines": {
-        "node": ">=18"
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@fastxyz/x402-server": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@fastxyz/x402-server/-/x402-server-1.0.1.tgz",
+      "integrity": "sha512-XKmAZTNk3qTC5fzDTuDcYFg0UEBO4B9I1kqCmj6nfOuEZriA2D8jTSw0uOOSwjfDTjjs5Anm92TrAl93jQ04jw==",
+      "dependencies": {
+        "@fastxyz/x402-types": "1.0.1"
       },
       "peerDependencies": {
-        "express": "^4.18.0"
+        "express": ">=4"
       },
       "peerDependenciesMeta": {
         "express": {
           "optional": true
         }
       }
+    },
+    "node_modules/@fastxyz/x402-types": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@fastxyz/x402-types/-/x402-types-1.0.1.tgz",
+      "integrity": "sha512-cQS6IG9QvXkHy9EK3P+Er5FhA58ySejeeWVXSok4SovCumZj+qnk03rVMZyUeTyHyXTtoodJKc09qIjL6hf5RA==",
+      "license": "MIT"
     },
     "node_modules/@floating-ui/core": {
       "version": "1.7.5",
@@ -2184,6 +2221,12 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "license": "MIT"
+    },
     "node_modules/@swc/helpers": {
       "version": "0.5.15",
       "license": "Apache-2.0",
@@ -3416,6 +3459,16 @@
       "version": "1.1.1",
       "license": "MIT"
     },
+    "node_modules/effect": {
+      "version": "3.21.0",
+      "resolved": "https://registry.npmjs.org/effect/-/effect-3.21.0.tgz",
+      "integrity": "sha512-PPN80qRokCd1f015IANNhrwOnLO7GrrMQfk4/lnZRE/8j7UPWrNNjPV0uBrZutI/nHzernbW+J0hdqQysHiSnQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "fast-check": "^3.23.1"
+      }
+    },
     "node_modules/encodeurl": {
       "version": "2.0.0",
       "license": "MIT",
@@ -3640,6 +3693,28 @@
       },
       "peerDependencies": {
         "express": ">= 4.11"
+      }
+    },
+    "node_modules/fast-check": {
+      "version": "3.23.2",
+      "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-3.23.2.tgz",
+      "integrity": "sha512-h5+1OzzfCC3Ef7VbtKdcv7zsstUQwUDlYpUTvjeUsJAssPgLn7QzbboPtL5ro04Mq0rPOsMzl7q5hIbRs2wD1A==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "pure-rand": "^6.1.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
       }
     },
     "node_modules/fast-deep-equal": {
@@ -4047,6 +4122,12 @@
       "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
       "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
       "license": "BSD-2-Clause"
+    },
+    "node_modules/json-with-bigint": {
+      "version": "3.5.8",
+      "resolved": "https://registry.npmjs.org/json-with-bigint/-/json-with-bigint-3.5.8.tgz",
+      "integrity": "sha512-eq/4KP6K34kwa7TcFdtvnftvHCD9KvHOGGICWwMFc4dOOKF5t4iYqnfLK8otCRCRv06FXOzGGyqE8h8ElMvvdw==",
+      "license": "MIT"
     },
     "node_modules/lightningcss": {
       "version": "1.32.0",
@@ -4957,6 +5038,22 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/pure-rand": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-6.1.0.tgz",
+      "integrity": "sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/qs": {
       "version": "6.14.2",
@@ -6340,7 +6437,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@fastxyz/sdk": "^0.2.5",
-        "@fastxyz/x402-client": "^0.1.2",
+        "@fastxyz/x402-client": "^0.1.3",
         "@noble/ed25519": "^3.0.1",
         "@noble/hashes": "^2.0.1",
         "ajv": "^8.18.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,8 @@
         "packages/*"
       ],
       "dependencies": {
-        "@fastxyz/fast-connector": "^0.1.1",
-        "@fastxyz/sdk": "^0.2.5",
+        "@fastxyz/fast-connector": "^0.1.2",
+        "@fastxyz/sdk": "^1.0.1",
         "@fastxyz/x402-client": "^0.1.3",
         "@fastxyz/x402-facilitator": "^1.0.1",
         "@fastxyz/x402-server": "^1.0.1",
@@ -417,9 +417,9 @@
       }
     },
     "node_modules/@fastxyz/fast-connector": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@fastxyz/fast-connector/-/fast-connector-0.1.1.tgz",
-      "integrity": "sha512-iJhGac9DplXNCnCCQzNQfoCIO8QA4NISQYDmwzY+vJK1L1oixuMzBg00nQ0gBnyEZDf8n2o6qeGkVLU+y+DWGw==",
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@fastxyz/fast-connector/-/fast-connector-0.1.2.tgz",
+      "integrity": "sha512-uq/GotuUqLXiz4dXRRBnXvKAqQZEegrfbKtY6I/fxBAKw+4OQvlyL4AgTk58m86bb3cyLqf9BeEvTNuCPxg+6w==",
       "license": "MIT",
       "dependencies": {
         "@mysten/bcs": "^2.0.2",
@@ -429,7 +429,7 @@
         "node": ">=20"
       },
       "peerDependencies": {
-        "@fastxyz/sdk": ">=0.1.8"
+        "@fastxyz/sdk": "^1.0.1"
       }
     },
     "node_modules/@fastxyz/schema": {
@@ -443,19 +443,38 @@
       }
     },
     "node_modules/@fastxyz/sdk": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/@fastxyz/sdk/-/sdk-0.2.5.tgz",
-      "integrity": "sha512-a2LxkxhmUEcqmGn159ausanthwB5EX2ebm+ElAhv/vwnHD4CwS269B1279RB75XitR0vANm8CZcLX2/+xCo6+w==",
-      "license": "MIT",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@fastxyz/sdk/-/sdk-1.0.1.tgz",
+      "integrity": "sha512-oE4llbFidOS6du4VmDuFMPgLv34bk/EQKwl0H1cWoibG9yZca47aWKVm2iwgYmsl9o1RVoHUOw4Lz4RVW71sJQ==",
       "dependencies": {
-        "@mysten/bcs": "^2.0.2",
-        "@noble/ed25519": "^2.1.0",
-        "@noble/hashes": "^1.5.0",
-        "@scure/base": "^2.0.0",
-        "bech32": "^2.0.0"
-      },
+        "@fastxyz/schema": "1.0.1",
+        "@mysten/bcs": "^2.0.3",
+        "@noble/ed25519": "^3.0.1",
+        "@noble/hashes": "^2.0.1",
+        "bech32": "^2.0.0",
+        "effect": "^3.21.0",
+        "json-with-bigint": "^3.5.8"
+      }
+    },
+    "node_modules/@fastxyz/sdk/node_modules/@noble/ed25519": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@noble/ed25519/-/ed25519-3.0.1.tgz",
+      "integrity": "sha512-t/T8LuK0ym8ALQudCCQCtrRdMSxBnRgHXw+wg+YsSlE6d+on7sX3flqlSJ2mOs9xEuchM36kj9SuX5MG7pXQMA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@fastxyz/sdk/node_modules/@noble/hashes": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.0.1.tgz",
+      "integrity": "sha512-XlOlEbQcE9fmuXxrVTXCTlG2nlRXa9Rj3rr5Ue/+tX+nmkgbX720YHh0VR3hBF9xDvwnb8D2shVGOwNx+ulArw==",
+      "license": "MIT",
       "engines": {
-        "node": ">=20"
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@fastxyz/x402-client": {
@@ -471,6 +490,22 @@
         "@noble/hashes": "^1.5.0",
         "bech32": "^2.0.0",
         "viem": "^2.46.2"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@fastxyz/x402-client/node_modules/@fastxyz/sdk": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/@fastxyz/sdk/-/sdk-0.2.5.tgz",
+      "integrity": "sha512-a2LxkxhmUEcqmGn159ausanthwB5EX2ebm+ElAhv/vwnHD4CwS269B1279RB75XitR0vANm8CZcLX2/+xCo6+w==",
+      "license": "MIT",
+      "dependencies": {
+        "@mysten/bcs": "^2.0.2",
+        "@noble/ed25519": "^2.1.0",
+        "@noble/hashes": "^1.5.0",
+        "@scure/base": "^2.0.0",
+        "bech32": "^2.0.0"
       },
       "engines": {
         "node": ">=20"
@@ -493,41 +528,6 @@
         "express": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@fastxyz/x402-facilitator/node_modules/@fastxyz/sdk": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@fastxyz/sdk/-/sdk-1.0.1.tgz",
-      "integrity": "sha512-oE4llbFidOS6du4VmDuFMPgLv34bk/EQKwl0H1cWoibG9yZca47aWKVm2iwgYmsl9o1RVoHUOw4Lz4RVW71sJQ==",
-      "dependencies": {
-        "@fastxyz/schema": "1.0.1",
-        "@mysten/bcs": "^2.0.3",
-        "@noble/ed25519": "^3.0.1",
-        "@noble/hashes": "^2.0.1",
-        "bech32": "^2.0.0",
-        "effect": "^3.21.0",
-        "json-with-bigint": "^3.5.8"
-      }
-    },
-    "node_modules/@fastxyz/x402-facilitator/node_modules/@noble/ed25519": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@noble/ed25519/-/ed25519-3.0.1.tgz",
-      "integrity": "sha512-t/T8LuK0ym8ALQudCCQCtrRdMSxBnRgHXw+wg+YsSlE6d+on7sX3flqlSJ2mOs9xEuchM36kj9SuX5MG7pXQMA==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/@fastxyz/x402-facilitator/node_modules/@noble/hashes": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.0.1.tgz",
-      "integrity": "sha512-XlOlEbQcE9fmuXxrVTXCTlG2nlRXa9Rj3rr5Ue/+tX+nmkgbX720YHh0VR3hBF9xDvwnb8D2shVGOwNx+ulArw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 20.19.0"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@fastxyz/x402-server": {
@@ -6436,7 +6436,7 @@
       "name": "@marketplace/cli",
       "version": "0.0.0",
       "dependencies": {
-        "@fastxyz/sdk": "^0.2.5",
+        "@fastxyz/sdk": "^1.0.1",
         "@fastxyz/x402-client": "^0.1.3",
         "@noble/ed25519": "^3.0.1",
         "@noble/hashes": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -34,8 +34,8 @@
     "start:cli": "node dist/packages/cli/index.js"
   },
   "dependencies": {
-    "@fastxyz/fast-connector": "^0.1.1",
-    "@fastxyz/sdk": "^0.2.5",
+    "@fastxyz/fast-connector": "^0.1.2",
+    "@fastxyz/sdk": "^1.0.1",
     "@fastxyz/x402-client": "^0.1.3",
     "@fastxyz/x402-facilitator": "^1.0.1",
     "@fastxyz/x402-server": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -34,11 +34,11 @@
     "start:cli": "node dist/packages/cli/index.js"
   },
   "dependencies": {
-    "@fastxyz/fast-connector": "^0.1.0",
+    "@fastxyz/fast-connector": "^0.1.1",
     "@fastxyz/sdk": "^0.2.5",
-    "@fastxyz/x402-client": "^0.1.2",
-    "@fastxyz/x402-facilitator": "^0.1.2",
-    "@fastxyz/x402-server": "^0.1.2",
+    "@fastxyz/x402-client": "^0.1.3",
+    "@fastxyz/x402-facilitator": "^1.0.1",
+    "@fastxyz/x402-server": "^1.0.1",
     "@noble/ed25519": "^2.3.0",
     "@noble/hashes": "^1.8.0",
     "ajv": "^8.18.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -8,7 +8,7 @@
     "fast-marketplace": "./dist/index.js"
   },
   "dependencies": {
-    "@fastxyz/sdk": "^0.2.5",
+    "@fastxyz/sdk": "^1.0.1",
     "@fastxyz/x402-client": "^0.1.3",
     "@noble/ed25519": "^3.0.1",
     "@noble/hashes": "^2.0.1",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "@fastxyz/sdk": "^0.2.5",
-    "@fastxyz/x402-client": "^0.1.2",
+    "@fastxyz/x402-client": "^0.1.3",
     "@noble/ed25519": "^3.0.1",
     "@noble/hashes": "^2.0.1",
     "ajv": "^8.18.0",

--- a/packages/cli/src/lib.ts
+++ b/packages/cli/src/lib.ts
@@ -4,10 +4,10 @@ import { dirname, resolve } from "node:path";
 import { stderr, stdin as input } from "node:process";
 import { createInterface } from "node:readline/promises";
 
-import { getPublicKeyAsync } from "@noble/ed25519";
-import { FastProvider, FastWallet, encodeFastAddress } from "@fastxyz/sdk";
+import { FastProvider } from "@fastxyz/sdk";
 import { x402Pay } from "@fastxyz/x402-client";
 import {
+  MarketplaceFastWallet,
   PAYMENT_IDENTIFIER_HEADER,
   buildRouteRef,
   createOpaqueToken,
@@ -43,7 +43,7 @@ export interface CliConfig {
 
 export interface LoadedWallet {
   keyfilePath: string;
-  wallet: FastWallet;
+  wallet: MarketplaceFastWallet;
   paymentWallet: {
     type: "fast";
     privateKey: string;
@@ -166,7 +166,7 @@ export async function initializeWallet(input: {
     deploymentNetwork: input.network,
     rpcUrl: input.rpcUrl
   });
-  const wallet = await FastWallet.generate(provider);
+  const wallet = await MarketplaceFastWallet.generate(provider);
   await wallet.saveToKeyfile(keyfilePath);
 
   const config = await readCliConfig(input.configPath);
@@ -176,7 +176,7 @@ export async function initializeWallet(input: {
 
   return {
     keyfilePath,
-    address: wallet.address
+    address: await wallet.address
   };
 }
 
@@ -247,13 +247,12 @@ export async function loadWalletFromPrivateKey(input: {
   const config = await readCliConfig(input.configPath);
   const network = resolveCliNetwork(input.network, config.defaultNetwork, input.rpcUrl);
   const privateKey = normalizePrivateKeyHex(input.privateKey);
-  const publicKey = Buffer.from(await getPublicKeyAsync(Buffer.from(privateKey, "hex"))).toString("hex");
-  const address = encodeFastAddress(Buffer.from(publicKey, "hex"));
   const provider = createProvider({
     deploymentNetwork: network.deploymentNetwork,
     rpcUrl: network.rpcUrl
   });
-  const wallet = await FastWallet.fromPrivateKey(privateKey, provider);
+  const wallet = await MarketplaceFastWallet.fromPrivateKey(privateKey, provider);
+  const exported = await wallet.exportKeys();
 
   return {
     keyfilePath: input.sourceLabel ?? "env:private-key",
@@ -261,8 +260,8 @@ export async function loadWalletFromPrivateKey(input: {
     paymentWallet: {
       type: "fast",
       privateKey,
-      publicKey,
-      address: normalizeFastWalletAddress(address),
+      publicKey: exported.publicKey,
+      address: normalizeFastWalletAddress(exported.address),
       rpcUrl: network.rpcUrl
     }
   };
@@ -293,7 +292,7 @@ export async function walletBalance(input: {
   const config = await readCliConfig(input.configPath);
   const loaded = await loadWallet(input);
   const network = resolveCliNetwork(input.network, config.defaultNetwork, input.rpcUrl);
-  return loaded.wallet.balance(input.token ?? network.tokenSymbol);
+  return loaded.wallet.balance((input.token ?? network.tokenSymbol) as "USDC" | "testUSDC");
 }
 
 export async function searchMarketplace(
@@ -885,13 +884,7 @@ function createProvider(input: {
     rpcUrl: input.rpcUrl
   });
   return new FastProvider({
-    network: network.deploymentNetwork,
-    networks: {
-      [network.deploymentNetwork]: {
-        rpc: network.rpcUrl,
-        explorer: network.explorerUrl
-      }
-    }
+    rpcUrl: network.rpcUrl
   });
 }
 

--- a/packages/shared/src/auth.ts
+++ b/packages/shared/src/auth.ts
@@ -1,8 +1,7 @@
 import { createHmac, randomUUID, timingSafeEqual } from "node:crypto";
 
 import { verifyAsync } from "@noble/ed25519";
-import { decodeFastAddress, encodeFastAddress, hexToBytes } from "@fastxyz/sdk";
-import { utf8ToBytes } from "@fastxyz/sdk/core";
+import { fromFastAddress, fromHex, toFastAddress } from "@fastxyz/sdk";
 
 import {
   AUTH_CHALLENGE_TTL_MS,
@@ -24,8 +23,7 @@ function signValue(value: string, secret: string): string {
 
 export function normalizeFastWalletAddress(addressOrHex: string): string {
   if (addressOrHex.startsWith("fast1")) {
-    const decoded = decodeFastAddress(addressOrHex);
-    return encodeFastAddress(decoded.bytes);
+    return toFastAddress(fromFastAddress(addressOrHex));
   }
 
   const normalized = addressOrHex.startsWith("0x") ? addressOrHex.slice(2) : addressOrHex;
@@ -34,7 +32,7 @@ export function normalizeFastWalletAddress(addressOrHex: string): string {
     throw new Error("Fast wallet payer must be a canonical fast address or 32-byte hex public key.");
   }
 
-  return encodeFastAddress(hexToBytes(normalized));
+  return toFastAddress(fromHex(normalized));
 }
 
 export function createChallenge(input: {
@@ -86,9 +84,9 @@ export async function verifyWalletChallenge(input: {
     return false;
   }
 
-  const publicKey = decodeFastAddress(normalizedWallet).bytes;
-  const message = utf8ToBytes(challengeMessage(input.challenge));
-  const signature = hexToBytes(input.signature.startsWith("0x") ? input.signature.slice(2) : input.signature);
+  const publicKey = fromFastAddress(normalizedWallet);
+  const message = new TextEncoder().encode(challengeMessage(input.challenge));
+  const signature = fromHex(input.signature);
 
   return verifyAsync(signature, message, publicKey);
 }

--- a/packages/shared/src/fast-wallet.ts
+++ b/packages/shared/src/fast-wallet.ts
@@ -1,0 +1,176 @@
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { randomBytes } from "node:crypto";
+import { dirname } from "node:path";
+
+import { bcsSchema } from "@fastxyz/schema";
+import {
+  FastProvider,
+  Signer,
+  TransactionBuilder,
+  fromFastAddress,
+  fromHex,
+  hashHex,
+  toFastAddress,
+  toHex
+} from "@fastxyz/sdk";
+
+import { decimalToRawString } from "./amounts.js";
+import type { MarketplaceTokenSymbol } from "./network.js";
+
+function normalizePrivateKeyHex(privateKey: string): string {
+  const normalized = privateKey.startsWith("0x") ? privateKey.slice(2) : privateKey;
+  if (!/^[0-9a-fA-F]{64}$/.test(normalized)) {
+    throw new Error("Fast private key must be a 32-byte hex string.");
+  }
+
+  return normalized.toLowerCase();
+}
+
+function tokenConfig(token: MarketplaceTokenSymbol): { tokenId: string; networkId: "fast:mainnet" | "fast:testnet" } {
+  if (token === "testUSDC") {
+    return {
+      tokenId: "0xd73a0679a2be46981e2a8aedecd951c8b6690e7d5f8502b34ed3ff4cc2163b46",
+      networkId: "fast:testnet"
+    };
+  }
+
+  return {
+    tokenId: "0xc655a12330da6af361d281b197996d2bc135aaed3b66278e729c2222291e9130",
+    networkId: "fast:mainnet"
+  };
+}
+
+export class MarketplaceFastWallet {
+  private readonly privateKeyHex: string;
+  private readonly signer: Signer;
+  private readonly provider: FastProvider;
+  private readonly addressPromise: Promise<string>;
+  private readonly publicKeyPromise: Promise<Uint8Array>;
+
+  private constructor(privateKeyHex: string, provider: FastProvider) {
+    this.privateKeyHex = privateKeyHex;
+    this.signer = new Signer(privateKeyHex);
+    this.provider = provider;
+    this.addressPromise = this.signer.getFastAddress();
+    this.publicKeyPromise = this.signer.getPublicKey();
+  }
+
+  static async generate(provider: FastProvider): Promise<MarketplaceFastWallet> {
+    return new MarketplaceFastWallet(randomBytes(32).toString("hex"), provider);
+  }
+
+  static async fromPrivateKey(privateKey: string, provider: FastProvider): Promise<MarketplaceFastWallet> {
+    return new MarketplaceFastWallet(normalizePrivateKeyHex(privateKey), provider);
+  }
+
+  static async fromKeyfile(
+    input: { keyFile: string; createIfMissing: boolean },
+    provider: FastProvider
+  ): Promise<MarketplaceFastWallet> {
+    try {
+      const raw = await readFile(input.keyFile, "utf8");
+      const parsed = JSON.parse(raw) as { privateKey?: string };
+      if (!parsed.privateKey) {
+        throw new Error(`Keyfile is missing privateKey: ${input.keyFile}`);
+      }
+
+      return MarketplaceFastWallet.fromPrivateKey(parsed.privateKey, provider);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      if (!message.includes("ENOENT") || !input.createIfMissing) {
+        throw error;
+      }
+
+      const wallet = await MarketplaceFastWallet.generate(provider);
+      await wallet.saveToKeyfile(input.keyFile);
+      return wallet;
+    }
+  }
+
+  get address(): Promise<string> {
+    return this.addressPromise;
+  }
+
+  async exportKeys(): Promise<{ privateKey: string; publicKey: string; address: string }> {
+    const publicKey = await this.publicKeyPromise;
+    return {
+      privateKey: this.privateKeyHex,
+      publicKey: Buffer.from(publicKey).toString("hex"),
+      address: await this.addressPromise
+    };
+  }
+
+  async saveToKeyfile(keyFile: string): Promise<void> {
+    await mkdir(dirname(keyFile), { recursive: true });
+    await writeFile(keyFile, JSON.stringify({ privateKey: this.privateKeyHex }, null, 2), "utf8");
+  }
+
+  async sign(input: { message: string | Uint8Array }): Promise<{ signature: string }> {
+    const message =
+      typeof input.message === "string" ? new TextEncoder().encode(input.message) : input.message;
+    const signature = await this.signer.signMessage(message);
+    return {
+      signature: toHex(signature)
+    };
+  }
+
+  async balance(token: MarketplaceTokenSymbol): Promise<bigint> {
+    const { tokenId } = tokenConfig(token);
+    const accountInfo = await this.provider.getAccountInfo({
+      address: await this.publicKeyPromise,
+      tokenBalancesFilter: null,
+      stateKeyFilter: null,
+      certificateByNonce: null
+    });
+
+    const normalizedTokenId = tokenId.replace(/^0x/, "");
+    for (const [candidateTokenId, balance] of accountInfo.tokenBalance) {
+      if (toHex(candidateTokenId).replace(/^0x/, "") === normalizedTokenId) {
+        return balance;
+      }
+    }
+
+    return 0n;
+  }
+
+  async send(input: { to: string; amount: string; token: MarketplaceTokenSymbol }): Promise<{ txHash: string }> {
+    const { tokenId, networkId } = tokenConfig(input.token);
+    const accountInfo = await this.provider.getAccountInfo({
+      address: await this.publicKeyPromise,
+      tokenBalancesFilter: null,
+      stateKeyFilter: null,
+      certificateByNonce: null
+    });
+    const recipient = input.to.startsWith("fast1") ? fromFastAddress(input.to) : fromHex(input.to);
+    const envelope = await new TransactionBuilder({
+      networkId,
+      signer: this.signer,
+      nonce: accountInfo.nextNonce
+    })
+      .addTokenTransfer({
+        tokenId: fromHex(tokenId),
+        recipient,
+        amount: BigInt(decimalToRawString(input.amount, 6)),
+        userData: null
+      })
+      .sign();
+
+    const submitResult = await this.provider.submitTransaction(envelope);
+    if (submitResult.type !== "Success") {
+      throw new Error(`Transaction submission failed: ${submitResult.type}`);
+    }
+
+    const tx = submitResult.value.envelope.transaction;
+    return {
+      txHash: await hashHex(bcsSchema.VersionedTransaction, { [tx.type]: tx.value } as never)
+    };
+  }
+}
+
+export function normalizeFastAddressBytes(address: string): Uint8Array {
+  return address.startsWith("fast1") ? fromFastAddress(address) : fromHex(address);
+}
+
+export function normalizeFastAddress(address: string): string {
+  return toFastAddress(normalizeFastAddressBytes(address));
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -5,6 +5,7 @@ export * from "./billing.js";
 export * from "./catalog.js";
 export * from "./constants.js";
 export * from "./docs.js";
+export * from "./fast-wallet.js";
 export * from "./hashing.js";
 export * from "./json-schema.js";
 export * from "./mock-provider.js";

--- a/packages/shared/src/payment.ts
+++ b/packages/shared/src/payment.ts
@@ -50,6 +50,10 @@ export function buildPaymentRequirementForRoute(route: MarketplaceRoute, payTo: 
     {
       price: quotedPriceString(route, requestBody),
       network: route.network,
+      networkConfig: {
+        asset: getMarketplaceAssetId(route.network),
+        decimals: 6
+      },
       config: {
         description: route.description,
         mimeType: "application/json",
@@ -66,6 +70,10 @@ export function buildPaymentRequiredResponse(route: MarketplaceRoute, payTo: str
     {
       price: quotedPriceString(route, requestBody),
       network: route.network,
+      networkConfig: {
+        asset: getMarketplaceAssetId(route.network),
+        decimals: 6
+      },
       config: {
         description: route.description,
         mimeType: "application/json",

--- a/packages/shared/src/refund.ts
+++ b/packages/shared/src/refund.ts
@@ -1,6 +1,7 @@
-import { FastProvider, FastWallet } from "@fastxyz/sdk";
+import { FastProvider } from "@fastxyz/sdk";
 
 import { rawToDecimalString } from "./amounts.js";
+import { MarketplaceFastWallet } from "./fast-wallet.js";
 import { resolveMarketplaceNetworkConfig } from "./network.js";
 import type { MarketplaceDeploymentNetwork } from "./network.js";
 import type { PayoutService, RefundService } from "./types.js";
@@ -18,23 +19,17 @@ function createFastTreasurySender(input: FastTreasuryServiceInput) {
     rpcUrl: input.rpcUrl
   });
   const provider = new FastProvider({
-    network: network.deploymentNetwork,
-    networks: {
-      [network.deploymentNetwork]: {
-        rpc: network.rpcUrl,
-        explorer: network.explorerUrl
-      }
-    }
+    rpcUrl: network.rpcUrl
   });
 
-  let walletPromise: Promise<FastWallet> | null = null;
+  let walletPromise: Promise<MarketplaceFastWallet> | null = null;
 
   const getWallet = async () => {
     if (!walletPromise) {
       if (input.privateKey) {
-        walletPromise = FastWallet.fromPrivateKey(input.privateKey, provider);
+        walletPromise = MarketplaceFastWallet.fromPrivateKey(input.privateKey, provider);
       } else if (input.keyfilePath) {
-        walletPromise = FastWallet.fromKeyfile(
+        walletPromise = MarketplaceFastWallet.fromKeyfile(
           { keyFile: input.keyfilePath, createIfMissing: false },
           provider
         );

--- a/packages/shared/src/shared.test.ts
+++ b/packages/shared/src/shared.test.ts
@@ -1,8 +1,9 @@
-import { FastProvider, FastWallet } from "@fastxyz/sdk";
+import { FastProvider } from "@fastxyz/sdk";
 import { describe, expect, it } from "vitest";
 
 import {
   InMemoryMarketplaceStore,
+  MarketplaceFastWallet,
   PostgresMarketplaceStore,
   buildCatalogSearchResults,
   buildMarketplaceRouteDetail,
@@ -41,20 +42,14 @@ const TESTNET_SERVICE_DEFINITIONS = listServiceDefinitions(TESTNET_NETWORK_CONFI
 
 async function createTestWallet() {
   const provider = new FastProvider({
-    network: "mainnet",
-    networks: {
-      mainnet: {
-        rpc: "https://api.fast.xyz/proxy",
-        explorer: "https://explorer.fast.xyz"
-      }
-    }
+    rpcUrl: "https://api.fast.xyz/proxy"
   });
 
-  const wallet = await FastWallet.fromPrivateKey(TEST_PRIVATE_KEY, provider);
+  const wallet = await MarketplaceFastWallet.fromPrivateKey(TEST_PRIVATE_KEY, provider);
   const exported = await wallet.exportKeys();
   return {
     wallet,
-    address: wallet.address,
+    address: await wallet.address,
     publicKey: exported.publicKey
   };
 }


### PR DESCRIPTION
## Summary
- update the marketplace to @fastxyz/sdk 1.0.1 and @fastxyz/fast-connector 0.1.2
- update compatible payment packages to @fastxyz/x402-client 0.1.3, @fastxyz/x402-server 1.0.1, and @fastxyz/x402-facilitator 1.0.1
- add the required networkConfig fields when building x402 payment requirements for the new @fastxyz/x402-server contract
- migrate the marketplace direct Fast SDK usage to the 1.0 API via a local MarketplaceFastWallet wrapper around Signer, FastProvider, and TransactionBuilder

## Notes
This keeps the web wallet path on the published connector that now supports SDK 1.0 and updates the CLI, refund flow, auth helpers, and tests to the new SDK surface.

## Verification
- npm run build
- npm test